### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "sass-css3-mixins",
-  "version": "0.1",
+  "version": "0.1.0",
   "main": "css3-mixins.scss",
   "ignore": [
     "**/.*",


### PR DESCRIPTION
Apparently bower wants version numbers like this: "0.0.0" not "0.0". Sorry 'bout that. Once fixed, "bower install sass-css3-mixins" will install the package.
