### PR TITLE
Adds a background-opacity mixin

### DIFF
--- a/css3-mixins.sass
+++ b/css3-mixins.sass
@@ -70,6 +70,10 @@
   -webkit-background-size: $width $height
   background-size: $width $height
 
+/* BACKGROUND COLOR OPACITY */
+@mixin background-opacity($color, $opacity: 0.85)
+  background: $color
+  background: rgba($color, $opacity)
 
 /* BORDER RADIUS */
 @mixin border-radius($radius: 5px)

--- a/css3-mixins.scss
+++ b/css3-mixins.scss
@@ -71,6 +71,11 @@
           background-size: $width $height;
 }
 
+/* BACKGROUND COLOR OPACITY */
+@mixin background-opacity($color, $opacity: 0.85) {
+  background: $color;
+  background: rgba($color, $opacity);
+}
 
 /* BORDER RADIUS */
 @mixin border-radius($radius: 5px) {


### PR DESCRIPTION
Adds background-opacity mixin so it's possible to do things like:

@include background-opacity(#ccc, 0.5)

Inspired by https://stackoverflow.com/questions/10929458/sass-converting-hex-to-rgba-for-background-opacity
