### PR TITLE
keyframes Quick fix

### DIFF
--- a/css3-mixins.scss
+++ b/css3-mixins.scss
@@ -242,19 +242,19 @@
 
 /* KEYFRAMES */
 @mixin keyframes($animation-name) {
-  @-webkit-keyframes $animation-name {
+  @-webkit-keyframes #{$animation-name} {
     @content;
   }
-  @-moz-keyframes $animation-name {
+  @-moz-keyframes #{$animation-name} {
     @content;
   }  
-  @-ms-keyframes $animation-name {
+  @-ms-keyframes #{$animation-name} {
     @content;
   }
-  @-o-keyframes $animation-name {
+  @-o-keyframes #{$animation-name} {
     @content;
   }  
-  @keyframes $animation-name {
+  @keyframes #{$animation-name} {
     @content;
   }
 }


### PR DESCRIPTION
After using this mixins library I found that the keyframe mixin is broken, and the solution is to add a hashtag followed by curly brackets to the animation-name variable.
