### PR TITLE
Remove incorrect IE filter for background-radial

### DIFF
--- a/css3-mixins.sass
+++ b/css3-mixins.sass
@@ -75,7 +75,6 @@
   background: -o-radial-gradient(center, ellipse cover, $startColor $startPos,$endColor $endPos)
   background: -ms-radial-gradient(center, ellipse cover, $startColor $startPos,$endColor $endPos)
   background: radial-gradient(ellipse at center, $startColor $startPos,$endColor $endPos)
-  filter:     progid:DXImageTransform.Microsoft.gradient( startColorstr='#{$startColor}', endColorstr='#{$endColor}',GradientType=1 )
 
 
 /* BACKGROUND SIZE */

--- a/css3-mixins.scss
+++ b/css3-mixins.scss
@@ -76,7 +76,6 @@
     background: -o-radial-gradient(center, ellipse cover, $startColor $startPos,$endColor $endPos);
     background: -ms-radial-gradient(center, ellipse cover, $startColor $startPos,$endColor $endPos);
     background: radial-gradient(ellipse at center, $startColor $startPos,$endColor $endPos);
-    filter:     progid:DXImageTransform.Microsoft.gradient( startColorstr='#{$startColor}', endColorstr='#{$endColor}',GradientType=1 );
 }
 
 /* BACKGROUND SIZE */


### PR DESCRIPTION
Internet Explorer don't supports radial gradients so I've removed incorrect 'filter' rule.
