### PR TITLE
use one-line comment style for unnecessary comments.

### DIFF
--- a/css3-mixins.sass
+++ b/css3-mixins.sass
@@ -47,7 +47,7 @@
 
  *-------------------------------------------------------------*/
 
- /* ADDS A BROWSER PREFIX TO THE PROPERTY */
+ // ADDS A BROWSER PREFIX TO THE PROPERTY
  @mixin css3-prefix($property, $value)
    -webkit-#{$property}: #{$value}
     -khtml-#{$property}: #{$value}
@@ -56,7 +56,7 @@
         -o-#{$property}: #{$value}
            #{$property}: #{$value}
 
-/* BACKGROUND GRADIENT */
+// BACKGROUND GRADIENT
 @mixin background-gradient($startColor: #3C3C3C, $endColor: #999999)
   background-color: $startColor
   background-image: -webkit-gradient(linear, left top, left bottom, from($startColor), to($endColor))
@@ -67,7 +67,7 @@
   background-image:         linear-gradient(top, $startColor, $endColor)
   filter:            progid:DXImageTransform.Microsoft.gradient(startColorStr='#{$startColor}', endColorStr='#{$endColor}')
 
-/* BACKGROUND HORIZONTAL */
+// BACKGROUND HORIZONTAL
 @mixin background-horizontal($startColor: #3C3C3C, $endColor: #999999)
     background-color: $startColor
     background-image: -webkit-gradient(linear, left top, right top, from($startColor), to($endColor))
@@ -78,7 +78,7 @@
     background-image:         linear-gradient(left, $startColor, $endColor)
     filter:            progid:DXImageTransform.Microsoft.gradient(startColorStr='#{$startColor}', endColorStr='#{$endColor}', gradientType='1')
 
-/* BACKGROUND RADIAL */
+// BACKGROUND RADIAL
 @mixin background-radial($startColor: #FFFFFF, $startPos: 0%, $endColor: #000000, $endPos:100%)
   background: -moz-radial-gradient(center, ellipse cover, $startColor $startPos, $endColor $endPos)
   background: -webkit-gradient(radial, center center, 0px, center center, 100%, color-stop($startPos,$startColor), color-stop($endPos,$endColor))
@@ -88,19 +88,19 @@
   background: radial-gradient(ellipse at center, $startColor $startPos,$endColor $endPos)
 
 
-/* BACKGROUND SIZE */
+// BACKGROUND SIZE
 @mixin background-size($width: 100%, $height: $width)
   @if (type-of($width) == 'number' and $height != null)
     @include css3-prefix('background-size', $width $height)
   @else
     @include css3-prefix('background-size', $width)
 
-/* BACKGROUND COLOR OPACITY */
+// BACKGROUND COLOR OPACITY
 @mixin background-opacity($color: #000, $opacity: 0.85)
   background: $color
   background: rgba($color, $opacity)
 
-/* BORDER RADIUS */
+// BORDER RADIUS
 @mixin border-radius($radius: 5px)
   @include css3-prefix('border-radius', $radius)
 
@@ -120,7 +120,7 @@
   border-bottom-right-radius: $bottomRightRadius
   border-bottom-left-radius:  $bottomLeftRadius
 
-/* BOX */
+// BOX
 @mixin box($orient: horizontal, $pack: center, $align: center)
   display: -webkit-box
   display: -moz-box
@@ -130,7 +130,7 @@
   @include css3-prefix('box-pack', $pack)
   @include css3-prefix('box-align', $align)
 
-/* BOX RGBA */
+// BOX RGBA
 @mixin box-rgba($r: 60, $g: 3, $b: 12, $opacity: 0.23, $color: #3C3C3C)
   background-color: transparent
   background-color: rgba($r, $g, $b, $opacity)
@@ -138,23 +138,23 @@
   zoom:   1
 
 
-/* BOX SHADOW */
+// BOX SHADOW
 @mixin box-shadow($x: 2px, $y: 2px, $blur: 5px, $color: rgba(0,0,0,.4), $inset: '')
   @if ($inset != "")
     @include css3-prefix('box-shadow', $inset $x $y $blur $color)
   @else
     @include css3-prefix('box-shadow', $x $y $blur $color)
 
-/* BOX SIZING */
+// BOX SIZING
 @mixin box-sizing($type: border-box)
   @include css3-prefix('box-sizing', $type)
 
-/* COLUMNS */
+// COLUMNS
 @mixin columns($count: 3, $gap: 10)
   @include css3-prefix('column-count', $count)
   @include css3-prefix('column-gap', $gap)
 
-/* DOUBLE BORDERS */
+// DOUBLE BORDERS
 @mixin double-borders($colorOne: #3C3C3C, $colorTwo: #999999, $radius: 0)
   border: 1px solid $colorOne
 
@@ -162,22 +162,22 @@
 
   @include border-radius( $radius )
 
-/* FLEX */
+// FLEX
 @mixin flex($value: 1)
   @include css3-prefix('box-flex', $value)
 
-/* FLIP */
+// FLIP
 @mixin flip($scaleX: -1)
   @include css3-prefix('transform', scaleX($scaleX))
   filter:            FlipH
   -ms-filter:        "FlipH"
 
-/* FONT FACE */
+// FONT FACE
 @mixin font-face($fontFamily: myFont, $eotFileSrc: 'myFont.eot', $woffFileSrc: 'myFont.woff', $ttfFileSrc: 'myFont.ttf', $svgFileSrc: 'myFont.svg', $svgFontID: '#myFont')
   font-family: $fontFamily
   src: url($eotFileSrc)  format('eot'), url($woffFileSrc) format('woff'), url($ttfFileSrc)  format('truetype'), url($svgFileSrc + $svgFontID) format('svg')
 
-/* OPACITY */
+// OPACITY
 @mixin opacity($opacity: 0.5)
   $opacityMultiplied: ($opacity * 100)
   filter:         alpha(opacity=$opacityMultiplied)
@@ -185,33 +185,33 @@
   @include css3-prefix('opacity', $opacity)
 
 
-/* OUTLINE RADIUS */
+// OUTLINE RADIUS
 @mixin outline-radius($radius: 5px)
   @include css3-prefix('outline-radius', $radius)
 
-/* RESIZE */
+// RESIZE
 @mixin resize($direction: both)
   @include css3-prefix('resize', $direction)
 
-/* ROTATE*/
+// ROTATE
 @mixin rotate($deg: 0, $m11: 0, $m12: 0, $m21: 0, $m22: 0)
   @include css3-prefix('transform', rotate($deg + deg))
   filter: progid:DXImageTransform.Microsoft.Matrix(M11=#{$m11}, M12=#{$m12}, M21=#{$m21}, M22=#{$m22}, sizingMethod='auto expand')
   zoom: 1
 
-/* TEXT SHADOW */
+// TEXT SHADOW
 @mixin text-shadow($x: 2px, $y: 2px, $blur: 5px, $color: rgba(0,0,0,.4))
   text-shadow: $x $y $blur $color
 
-/* TRANSFORM  */
+// TRANSFORM
 @mixin transform($params)
   @include css3-prefix('transform', $params)
 
-/* TRANSFORM STYLE */
+// TRANSFORM STYLE
 @mixin transform-style($style: preserve-3d)
   @include css3-prefix('transform-style', $style)
 
-/* TRANSITION */
+// TRANSITION
 @mixin transition($properties...)
   @if length($properties) >= 1
     @include css3-prefix('transition', $properties)
@@ -219,7 +219,7 @@
     @include css3-prefix('transition',  "all 0.2s ease-in-out 0s")
 
 
-/* TRIPLE BORDERS */
+// TRIPLE BORDERS
 @mixin triple-borders($colorOne: #3C3C3C, $colorTwo: #999999, $colorThree: #000000, $radius: 0)
   border: 1px solid $colorOne
 
@@ -228,7 +228,7 @@
   @include css3-prefix('box-shadow', "0 0 0 1px #{$colorTwo}, 0 0 0 2px #{$colorThree}")
 
 
-/* KEYFRAMES */
+// KEYFRAMES
 @mixin keyframes($animation-name)
   @-webkit-keyframes $animation-name
     @content
@@ -242,6 +242,6 @@
     @content
 
 
-/* ANIMATION */
+// ANIMATION
 @mixin animation($str)
   @include css3-prefix('animation', $str)

--- a/css3-mixins.scss
+++ b/css3-mixins.scss
@@ -47,7 +47,7 @@
 
 ------------------------------------------------------------- */
 
-/* ADDS A BROWSER PREFIX TO THE PROPERTY */
+// ADDS A BROWSER PREFIX TO THE PROPERTY
 @mixin css3-prefix($property, $value) {
   -webkit-#{$property}: #{$value};
    -khtml-#{$property}: #{$value};
@@ -57,7 +57,7 @@
           #{$property}: #{$value};
 }
 
-/* BACKGROUND GRADIENT */
+// BACKGROUND GRADIENT
 @mixin background-gradient($startColor: #3C3C3C, $endColor: #999999) {
     background-color: $startColor;
     background-image: -webkit-gradient(linear, left top, left bottom, from($startColor), to($endColor));
@@ -69,7 +69,7 @@
     filter:            progid:DXImageTransform.Microsoft.gradient(startColorStr='#{$startColor}', endColorStr='#{$endColor}');
 }
 
-/* BACKGROUND HORIZONTAL */
+// BACKGROUND HORIZONTAL
 @mixin background-horizontal($startColor: #3C3C3C, $endColor: #999999) {
     background-color: $startColor;
     background-image: -webkit-gradient(linear, left top, right top, from($startColor), to($endColor));
@@ -81,7 +81,7 @@
     filter:            progid:DXImageTransform.Microsoft.gradient(startColorStr='#{$startColor}', endColorStr='#{$endColor}', gradientType='1');
 }
 
-/* BACKGROUND RADIAL */
+// BACKGROUND RADIAL
 @mixin background-radial($startColor: #FFFFFF, $startPos: 0%, $endColor: #000000, $endPos:100%) {
     background: -moz-radial-gradient(center, ellipse cover, $startColor $startPos, $endColor $endPos);
     background: -webkit-gradient(radial, center center, 0px, center center, 100%, color-stop($startPos,$startColor), color-stop($endPos,$endColor));
@@ -91,7 +91,7 @@
     background: radial-gradient(ellipse at center, $startColor $startPos,$endColor $endPos);
 }
 
-/* BACKGROUND SIZE */
+// BACKGROUND SIZE
 @mixin background-size($width: 100%, $height: $width) {
   @if type-of($width) == 'number' and $height != null {
     @include css3-prefix('background-size', $width $height);
@@ -100,13 +100,13 @@
   }
 }
 
-/* BACKGROUND COLOR OPACITY */
+// BACKGROUND COLOR OPACITY
 @mixin background-opacity($color: #000, $opacity: 0.85) {
   background: $color;
   background: rgba($color, $opacity);
 }
 
-/* BORDER RADIUS */
+// BORDER RADIUS
 @mixin border-radius($radius: 5px) {
     @include css3-prefix('border-radius', $radius);
 }
@@ -128,7 +128,7 @@
   border-bottom-left-radius:  $bottomLeftRadius;
 }
 
-/* BOX */
+// BOX
 @mixin box($orient: horizontal, $pack: center, $align: center) {
   display: -webkit-box;
   display: -moz-box;
@@ -139,7 +139,7 @@
   @include css3-prefix('box-align', $align);
 }
 
-/* BOX RGBA */
+// BOX RGBA
 @mixin box-rgba($r: 60, $g: 3, $b: 12, $opacity: 0.23, $color: #3C3C3C) {
   background-color: transparent;
   background-color: rgba($r, $g, $b, $opacity);
@@ -148,7 +148,7 @@
 }
 
 
-/* BOX SHADOW */
+// BOX SHADOW
 @mixin box-shadow($x: 2px, $y: 2px, $blur: 5px, $color: rgba(0,0,0,.4), $inset: "") {
   @if ($inset != "") {
     @include css3-prefix('box-shadow', $inset $x $y $blur $color);
@@ -157,18 +157,18 @@
   }
 }
 
-/* BOX SIZING */
+// BOX SIZING
 @mixin box-sizing($type: border-box) {
   @include css3-prefix('box-sizing', $type);
 }
 
-/* COLUMNS */
+// COLUMNS
 @mixin columns($count: 3, $gap: 10) {
   @include css3-prefix('column-count', $count);
   @include css3-prefix('column-gap', $gap);
 }
 
-/* DOUBLE BORDERS */
+// DOUBLE BORDERS
 @mixin double-borders($colorOne: #3C3C3C, $colorTwo: #999999, $radius: 0) {
   border: 1px solid $colorOne;
 
@@ -177,19 +177,19 @@
   @include border-radius( $radius );
 }
 
-/* FLEX */
+// FLEX
 @mixin flex($value: 1) {
   @include css3-prefix('box-flex', $value);
 }
 
-/* FLIP */
+// FLIP
 @mixin flip($scaleX: -1) {
   @include css3-prefix('transform', scaleX($scaleX));
   filter:            FlipH;
   -ms-filter:        "FlipH";
 }
 
-/* FONT FACE */
+// FONT FACE
 @mixin font-face($fontFamily: myFont, $eotFileSrc: 'myFont.eot', $woffFileSrc: 'myFont.woff', $ttfFileSrc: 'myFont.ttf', $svgFileSrc: 'myFont.svg', $svgFontID: '#myFont') {
   font-family: $fontFamily;
   src: url($eotFileSrc)  format('eot'),
@@ -198,7 +198,7 @@
        url($svgFileSrc + $svgFontID) format('svg');
 }
 
-/* OPACITY */
+// OPACITY
 @mixin opacity($opacity: 0.5) {
     $opacityMultiplied: ($opacity * 100);
 
@@ -208,17 +208,17 @@
 }
 
 
-/* OUTLINE RADIUS */
+// OUTLINE RADIUS
 @mixin outline-radius($radius: 5px) {
   @include css3-prefix('outline-radius', $radius);
 }
 
-/* RESIZE */
+// RESIZE
 @mixin resize($direction: both) {
   @include css3-prefix('resize', $direction);
 }
 
-/* ROTATE*/
+// ROTATE
 @mixin rotate($deg: 0, $m11: 0, $m12: 0, $m21: 0, $m22: 0) {
   @include css3-prefix('transform', rotate($deg + deg));
   filter: progid:DXImageTransform.Microsoft.Matrix(
@@ -226,22 +226,22 @@
     zoom: 1;
 }
 
-/* TEXT SHADOW */
+// TEXT SHADOW
 @mixin text-shadow($x: 2px, $y: 2px, $blur: 5px, $color: rgba(0,0,0,.4)) {
     text-shadow: $x $y $blur $color;
 }
 
-/* TRANSFORM  */
+// TRANSFORM
 @mixin transform($params) {
   @include css3-prefix('transform', $params);
 }
 
-/* TRANSFORM STYLE */
+// TRANSFORM STYLE
 @mixin transform-style($style: preserve-3d) {
   @include css3-prefix('transform-style', $style);
 }
 
-/* TRANSITION */
+// TRANSITION
 @mixin transition($properties...) {
 
   @if length($properties) >= 1 {
@@ -253,7 +253,7 @@
   }
 }
 
-/* TRIPLE BORDERS */
+// TRIPLE BORDERS
 @mixin triple-borders($colorOne: #3C3C3C, $colorTwo: #999999, $colorThree: #000000, $radius: 0) {
     border: 1px solid $colorOne;
 
@@ -262,7 +262,7 @@
     @include css3-prefix('box-shadow', "0 0 0 1px #{$colorTwo}, 0 0 0 2px #{$colorThree}");
 }
 
-/* KEYFRAMES */
+// KEYFRAMES
 @mixin keyframes($animation-name) {
   @-webkit-keyframes #{$animation-name} {
     @content;
@@ -281,7 +281,7 @@
   }
 }
 
-/* ANIMATION */
+// ANIMATION
 @mixin animation($str) {
   @include css3-prefix('animation', $str);
 }


### PR DESCRIPTION
Should use one-line comment style to remove unnecessary comments in
compiled css file.

There are all comment lines display on top of css file after compiled.
Seem like unnecessary.

/* ADDS A BROWSER PREFIX TO THE PROPERTY */
/* BACKGROUND GRADIENT */
/* BACKGROUND HORIZONTAL */
/* BACKGROUND RADIAL */
/* BACKGROUND SIZE */
/* BACKGROUND COLOR OPACITY */
/* BORDER RADIUS */
/* BOX */
/* BOX RGBA */
/* BOX SHADOW */
/* BOX SIZING */
/* COLUMNS */
/* DOUBLE BORDERS */
/* FLEX */
/* FLIP */
/* FONT FACE */
/* OPACITY */
/* OUTLINE RADIUS */
/* RESIZE */
/* ROTATE*/
/* TEXT SHADOW */
/* TRANSFORM  */
/* TRANSFORM STYLE */
/* TRANSITION */
/* TRIPLE BORDERS */
/* KEYFRAMES */
/* ANIMATION */