### PR TITLE
Support for gradients in right-to-left direction.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ http://mynameismatthieu.com/sass-css3-mixins/
    <td>Start Color: #3C3C3C, End Color: #999999</td>
  </tr>
  <tr>
+   <td>background-horizontal-inverse</td>
+   <td>Start Color: #999999, End Color: #3C3C3C</td>
+ </tr>
+ <tr>
    <td>background-radial</td>
    <td>Start Color: #FFFFFF, Start position: 0%, End Color: #000000, End position: 100%</td>
  </tr>

--- a/css3-mixins.sass
+++ b/css3-mixins.sass
@@ -57,6 +57,20 @@
   background-image: linear-gradient(left, $startColor, $endColor)
   filter: progid:DXImageTransform.Microsoft.gradient(startColorStr='#{$startColor}', endColorStr='#{$endColor}', gradientType='1')
 
+/// Background Horizontal - inverse direction
+/// @param {Color} $startColor [#999999] - Start Color
+/// @param {Color} $endColor [#3C3C3C] - End Color
+
+=background-horizontal($startColor: #999999, $endColor: #3C3C3C)
+  background-color: $startColor
+  background-image: -webkit-gradient(linear, right top, left top, from($startColor), to($endColor))
+  background-image: -webkit-linear-gradient(right, $startColor, $endColor)
+  background-image: -moz-linear-gradient(right, $startColor, $endColor)
+  background-image: -ms-linear-gradient(right, $startColor, $endColor)
+  background-image: -o-linear-gradient(right, $startColor, $endColor)
+  background-image: linear-gradient(right, $startColor, $endColor)
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorStr='#{$endColor}', endColorStr='#{$startColor}', gradientType='1')
+
 /// Background Radial
 /// @param {Color} $startColor [#3C3C3C] - Start Color
 /// @param {Percentage} $startPos [0%] - Start position

--- a/css3-mixins.scss
+++ b/css3-mixins.scss
@@ -65,6 +65,22 @@
 }
 
 
+/// Background Horizontal - inverse direction
+/// @param {Color} $startColor [#999999] - Start Color
+/// @param {Color} $endColor [#3C3C3C] - End Color
+
+@mixin background-horizontal-inverse($startColor: #999999, $endColor: #3C3C3C) {
+    background-color: $startColor;
+    background-image: -webkit-gradient(linear, right top, left top, from($startColor), to($endColor));
+    background-image: -webkit-linear-gradient(rigth, $startColor, $endColor);
+    background-image:    -moz-linear-gradient(rigth, $startColor, $endColor);
+    background-image:     -ms-linear-gradient(rigth, $startColor, $endColor);
+    background-image:      -o-linear-gradient(rigth, $startColor, $endColor);
+    background-image:         linear-gradient(rigth, $startColor, $endColor);
+    filter:            progid:DXImageTransform.Microsoft.gradient(startColorStr='#{$endColor}', endColorStr='#{$startColor}', gradientType='1');
+}
+
+
 /// Background Radial
 /// @param {Color} $startColor [#3C3C3C] - Start Color
 /// @param {Percentage} $startPos [0%] - Start position

--- a/css3-mixins.scss
+++ b/css3-mixins.scss
@@ -72,11 +72,11 @@
 @mixin background-horizontal-inverse($startColor: #999999, $endColor: #3C3C3C) {
     background-color: $startColor;
     background-image: -webkit-gradient(linear, right top, left top, from($startColor), to($endColor));
-    background-image: -webkit-linear-gradient(rigth, $startColor, $endColor);
-    background-image:    -moz-linear-gradient(rigth, $startColor, $endColor);
-    background-image:     -ms-linear-gradient(rigth, $startColor, $endColor);
-    background-image:      -o-linear-gradient(rigth, $startColor, $endColor);
-    background-image:         linear-gradient(rigth, $startColor, $endColor);
+    background-image: -webkit-linear-gradient(right, $startColor, $endColor);
+    background-image:    -moz-linear-gradient(right, $startColor, $endColor);
+    background-image:     -ms-linear-gradient(right, $startColor, $endColor);
+    background-image:      -o-linear-gradient(right, $startColor, $endColor);
+    background-image:         linear-gradient(right, $startColor, $endColor);
     filter:            progid:DXImageTransform.Microsoft.gradient(startColorStr='#{$endColor}', endColorStr='#{$startColor}', gradientType='1');
 }
 


### PR DESCRIPTION
I've added a mixin for horizontal gradients in opposite direction (right-to-left). It's needed because flipping the order of argument in `horizontal-gradient` isn't enought and produces inconcistent value for `background-color` and `filter`. Example:

```
// gradient from #7e7e7e to #ffffff, outputs background-color: #7e7e7e;
@include background-horizontal($startColor: rgba(126,126,126,1), $endColor: rgba(255,255,255,1))

// gradient from #ffffff to #7e7e7e, outputs background-color: #ffffff;
@include background-horizontal($startColor: rgba(255,255,255,1), $endColor: rgba(126,126,126,1))

// gradient from #ffffff to to #7e7e7e, outputs background-color: #7e7e7e;
@include background-horizontal-inverse($startColor: rgba(126,126,126,1), $endColor: rgba(255,255,255,1))
```
